### PR TITLE
Suggestion - add HMS to footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -6,5 +6,5 @@
       </a>
     </li>
 </ul> -->
-  Copyright © <a href="hidivelab.org">HIDIVE Lab</a> 2024. All rights reserved.
+  Copyright © 2024 <a href="hidivelab.org">HIDIVE Lab</a> at Harvard Medical School. All rights reserved.
 </footer>

--- a/index.md
+++ b/index.md
@@ -8,7 +8,7 @@ title: Home
     Inclusive Science Data Accessibility Report
 </div>
 <div class='subtitle'>
-    INSCIDAR is an open platform to share and communicate the digital accessibility states of life sciences data resources. We perform accessibility evaluation regularly and share evaluation results in the form of data, online reports, and research publications. Our mission is to increase the accessibility of life sciences data resources, lowering barriers for people with disabilities to join the life sciences workforce.
+    <span lang="en" aria-label="insider">INSCIDAR</span> (pronounced "insider") is an open platform to share and communicate the digital accessibility states of life sciences data resources. We perform accessibility evaluation regularly and share evaluation results in the form of data, online reports, and research publications. Our mission is to increase the accessibility of life sciences data resources, lowering barriers for people with disabilities to join the life sciences workforce.
 
     This effort was initiated by the members of the HIDIVE Lab at Harvard Medical School (see <a href="https://hidivelab.org/research/teams/accessibility/our-accessibility-journey">Our Accessibility Journey</a>).
 </div>

--- a/index.md
+++ b/index.md
@@ -8,7 +8,7 @@ title: Home
     Inclusive Science Data Accessibility Report
 </div>
 <div class='subtitle'>
-    <span lang="en" aria-label="insider">INSCIDAR</span> (pronounced "insider") is an open platform to share and communicate the digital accessibility states of life sciences data resources. We perform accessibility evaluation regularly and share evaluation results in the form of data, online reports, and research publications. Our mission is to increase the accessibility of life sciences data resources, lowering barriers for people with disabilities to join the life sciences workforce.
+    INSCIDAR is an open platform to share and communicate the digital accessibility states of life sciences data resources. We perform accessibility evaluation regularly and share evaluation results in the form of data, online reports, and research publications. Our mission is to increase the accessibility of life sciences data resources, lowering barriers for people with disabilities to join the life sciences workforce.
 
     This effort was initiated by the members of the HIDIVE Lab at Harvard Medical School (see <a href="https://hidivelab.org/research/teams/accessibility/our-accessibility-journey">Our Accessibility Journey</a>).
 </div>


### PR DESCRIPTION
We mention “HIDIVE Lab at Harvard Medical School” in the content of the home page, but the HMS name is not on the other pages. I’s possible that someone might be sent directly to another page on the website, without seeing the home page. While people in our academic community are familiar with HIDIVE Lab, naming HMS would increase the chances of a broader audience (including journalists) recognizing the source, trusting it, and circulating it. The footer appears on every page, making it a natural place to include the name. 