### PR TITLE
Adjustments to preview tables

### DIFF
--- a/data.md
+++ b/data.md
@@ -119,7 +119,7 @@ All data is also available on [our GitHub repository for analysis](https://githu
         </div>
         <div id="file-content-{{ date | slugify }}-{{ file.name | slugify }}" class="file-content" hidden>
           <p>{{ file-desc.desc }}</p>
-          <div class="file-preview-header">File Preview (up to 4 rows and 12 columns):</div>
+          <div class="file-preview-header">File Preview (up to 4 rows):</div>
           <table class="file-preview">
           </table>
           <div class="file-name"><code>{{ file.name }}</code></div>
@@ -186,12 +186,18 @@ All data is also available on [our GitHub repository for analysis](https://githu
           const rows = csvText.split('\n').slice(0, 5); // max 5 rows
           const table = content.querySelector('table');
           let tableHTML = '';
-          
+          // we do not want to show the index column to save space
+          const firstColNull = rows[0]?.split(',')?.[0] === "";
           rows.forEach((row, rowIndex) => {
+            // to safely parse string values containing commas, replace commas with a predefined string
+            const COMMA_WITHIN_DOUBLE_QUOTE = '###COMMA###';
+            row = row.replace(/"(.*?)"/g, (str) => str.replaceAll(',', COMMA_WITHIN_DOUBLE_QUOTE));
             const columns = row.split(',');
             tableHTML += '<tr>';
-            console.log(columns.length);
-            columns.slice(0, 12).forEach(column => {
+            columns.forEach((column, colIndex) => {
+              // recover the commas within each column
+              column = column.replaceAll(COMMA_WITHIN_DOUBLE_QUOTE, ',');
+              if(firstColNull && colIndex === 0) return;
               if (rowIndex === 0) {
                 tableHTML += `<th>${column}</th>`;
               } else {

--- a/data.md
+++ b/data.md
@@ -119,7 +119,7 @@ All data is also available on [our GitHub repository for analysis](https://githu
         </div>
         <div id="file-content-{{ date | slugify }}-{{ file.name | slugify }}" class="file-content" hidden>
           <p>{{ file-desc.desc }}</p>
-          <div class="file-preview-header">File Preview (up to 4 rows and 10 columns):</div>
+          <div class="file-preview-header">File Preview (up to 4 rows and 12 columns):</div>
           <table class="file-preview">
           </table>
           <div class="file-name"><code>{{ file.name }}</code></div>
@@ -190,7 +190,8 @@ All data is also available on [our GitHub repository for analysis](https://githu
           rows.forEach((row, rowIndex) => {
             const columns = row.split(',');
             tableHTML += '<tr>';
-            columns.slice(0, 10).forEach(column => {
+            console.log(columns.length);
+            columns.slice(0, 12).forEach(column => {
               if (rowIndex === 0) {
                 tableHTML += `<th>${column}</th>`;
               } else {

--- a/data.md
+++ b/data.md
@@ -119,9 +119,10 @@ All data is also available on [our GitHub repository for analysis](https://githu
         </div>
         <div id="file-content-{{ date | slugify }}-{{ file.name | slugify }}" class="file-content" hidden>
           <p>{{ file-desc.desc }}</p>
-          <span class="file-name">File name: <code>{{ file.name }}</code></span>
+          <div class="file-preview-header">File Preview (up to 4 rows and 10 columns):</div>
           <table class="file-preview">
           </table>
+          <div class="file-name"><code>{{ file.name }}</code></div>
         </div>
       </li>
     {% endfor %}
@@ -166,7 +167,17 @@ All data is also available on [our GitHub repository for analysis](https://githu
     icon.src = isExpanded 
       ? "{{ '/assets/icons/triangle-right.svg' | relative_url }}" 
       : "{{ '/assets/icons/triangle-down.svg' | relative_url }}";
-    
+   
+    // format values of each cell in the table
+    const format = (str) => {
+      if(+str && +str % 1 !== 0) {
+        // float, e.g., str is "3.1429"
+        return (+str).toFixed(3);
+      } else {
+        return str;
+      }
+    }
+
     // check if expanded, else, fetch content
     if (!isExpanded && !content.getAttribute('data-loaded')) {
       fetch(filePath)
@@ -179,11 +190,11 @@ All data is also available on [our GitHub repository for analysis](https://githu
           rows.forEach((row, rowIndex) => {
             const columns = row.split(',');
             tableHTML += '<tr>';
-            columns.forEach(column => {
+            columns.slice(0, 10).forEach(column => {
               if (rowIndex === 0) {
                 tableHTML += `<th>${column}</th>`;
               } else {
-                tableHTML += `<td>${column}</td>`;
+                tableHTML += `<td>${format(column)}</td>`;
               }
             });
             tableHTML += '</tr>';
@@ -250,8 +261,11 @@ All data is also available on [our GitHub repository for analysis](https://githu
   }
 
   .file-name {
-    margin-left: 6px;
     font-style: italic;
+    display: inline-block;
+    text-align: right;
+    width: 100%;
+    color: grey;
   }
 
   .file-header {
@@ -259,24 +273,30 @@ All data is also available on [our GitHub repository for analysis](https://githu
     align-items: center;
   }
 
+  .file-preview-header {
+    color: grey;
+  }
+
   .file-preview {
-    width: 80%;
-    max-width: 600px;
+    width: calc(100% - 20px);
+    max-width: calc(100% - 20px);
     border-collapse: collapse;
     margin: 20px;
+    margin-bottom: 8px;
+    margin-right: 0px;
     box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
     position: relative;
     overflow: hidden;
     border-radius: 10px;
     background-color: #ffffff;
-    border: 2px solid #4caf50;
+    border: 2px solid #cc79a7;
     font-size: 12px;
   }
 
   .file-preview th, .file-preview td {
     padding: 8px;
     text-align: left;
-    border: 1px solid #4caf50;
+    border: 1px solid #cc79a7;
   }
 
   .file-preview th {
@@ -303,7 +323,7 @@ All data is also available on [our GitHub repository for analysis](https://githu
     left: 0;
     right: 0;
     height: 100px;
-    background: linear-gradient(to bottom, rgba(255, 255, 255, 0) 50%, rgba(255, 255, 255, 1) 100%);
+    background: linear-gradient(to bottom, rgba(255, 255, 255, 0) 80%, rgba(255, 255, 255, 1) 100%);
     pointer-events: none;
   }
 


### PR DESCRIPTION
Changes made in this PR:

- Replace the color of borders with our current theme color
- Simplify floats on tables (`.toFixed(3)`). Since these tables serve as "previews," I think it's okay not to show the most precise numbers.
- Limit the number of columns shown (up to 10)
- Clarify that tables are "previews" and that up to certain numbers of rows/columns are shown.
- Move the file name to the right bottom of each table.
- Ensure that the width of the table does not overflow the given space

![Screenshot 2024-12-12 at 11 14 24 AM](https://github.com/user-attachments/assets/16831901-a00d-4156-a736-70baf9e15d3d)
